### PR TITLE
Fix `--resources` did not find resources with `::`

### DIFF
--- a/lib/puppet/face/node/exports.rb
+++ b/lib/puppet/face/node/exports.rb
@@ -43,7 +43,7 @@ Puppet::Face.define(:node, '0.0.1') do
       connection = Puppet::Network::HttpPool.http_instance(Puppet::Util::Puppetdb.server,'8081')
       query = ["and",["=","exported",true]]
       if options[:resources]
-        types = options[:resources].split(',').map{|resource| ['=','type',resource.capitalize] }
+        types = options[:resources].split(',').map{|resource| ['=','type',resource] }
         query = query.concat(types)
       end
       json_query = URI.escape(query.to_json)


### PR DESCRIPTION
Running `puppet node exports --resources haproxy::balancermember` returned no rows. Changing capitalizations to `Haproxy::Balancermember` or `Haproxy::balancermember` did not return rows either.

By not capitalizing the resource, the caller is responsible for the correct capitalization, but also ensures we can find any resource. For example:

```
$ puppet node exports | grep Haproxy
carbon101.novalocal                       Haproxy::balancermember[carbon101-carbon]
carbon101.novalocal                       Haproxy::balancermember[carbon101-graphite]
```

But trying to find the resource using `--resources` did not work:

```
$ puppet node exports --resources haproxy::balancermember
Name                                      Exports

$ puppet node exports --resources Haproxy::balancermember
Name                                      Exports

$ puppet node exports --resources Haproxy::Balancermember
Name                                      Exports
```

But resources with a single word work just fine:

```
$ puppet node exports --resources nagios_service | head -n 2
Name                                      Exports
worker101.novalocal                       Nagios_service[check_apt worker101]
$ puppet node exports --resources Nagios_service | head -n 2
Name                                      Exports
worker101.novalocal                       Nagios_service[check_apt worker101]
```

After removing the call to `#capitalize`, one can find any resource:

```
$ puppet node exports --resources nagios_service | head -n 2
Name                                      Exports

$ puppet node exports --resources Haproxy::balancermember | head -n 2
Name                                      Exports

$ puppet node exports --resources Nagios_service | head -n 2
Name                                      Exports
worker101.novalocal                       Nagios_service[check_apt worker101]

$ puppet node exports --resources Haproxy::Balancermember | head -n 2
Name                                      Exports
carbon101.novalocal                       Haproxy::balancermember[carbon101-graphite]
```
