### PR TITLE
Correct doc for limiting by resource type

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ puppet3.puppetlabs.vm                User[foooo]
 ```
 To query for just user resources
 ```shell
-puppet node exports user
+puppet node exports --resources user
 ```
 
 ```shell


### PR DESCRIPTION
If I try to run `puppet node exports <type>`, I get an error:

```
Error: puppet node exports takes 0 arguments, but you gave 1
Error: Try 'puppet help node exports' for usage
```